### PR TITLE
Unicode text support

### DIFF
--- a/anybar/anybar.py
+++ b/anybar/anybar.py
@@ -22,8 +22,11 @@ class AnyBar():
             self.socket.sendto(color.encode('utf-8'),
                                (self.address, self.port))
         else:
-            self.socket.sendto('{} {}'.format(color, text).encode('utf-8'),
-                               (self.address, self.port))
+            if type(text) is unicode:
+                message = u'{} {}'.format(color, text).encode('utf-8')
+            else:
+                message = '{} {}'.format(color, text)
+            self.socket.sendto(message, (self.address, self.port))
 
 
 


### PR DESCRIPTION
Currently only the following format is supported:

`AnyBar().change('red', text='hello world')`

This commit adds unicode support, thus these are supported:

`AnyBar().change('red', text=u'你好 世界')`
`AnyBar().change('red', text='你好 世界!')`
